### PR TITLE
chore: allow version 1 of Mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "mockery/mockery": "^0.9",
+        "mockery/mockery": "^0.9|^1.0",
         "php-mock/php-mock-integration": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
Im using PHP 7.1 & phpunit 6.0 and having to use `dev-master as 1.0` with Mockery any chance you could allow `^1.0.0` so composer.. although as I write this Im thinking this package might not support phpunit 6.0 either :(

Actually I can do `dev-master#e139355 as 0.9.999999` to get around it for now.