### PR TITLE
qa: Update workflows - test with Mockery ~1.6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,11 @@ jobs:
             mockery-version: '0.9.0'
           - php-version: '7.4'
             mockery-version: '0.8.0'
-            
+
+          # PHP 7.3 Exclusions
+          - php-version: '7.3'
+            mockery-version: '1.6.0'
+
           # PHP 7.2 Exclusions
           - php-version: '7.2'
             mockery-version: '1.6.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           - '7.1'
           - '7.0'
         mockery-version:
+          - '1.6.0'
           - '1.5.0'
           - '1.4.0'
           - '1.3.0'
@@ -82,17 +83,23 @@ jobs:
             
           # PHP 7.2 Exclusions
           - php-version: '7.2'
+            mockery-version: '1.6.0'
+          - php-version: '7.2'
             mockery-version: '1.5.0'
           - php-version: '7.2'
             mockery-version: '1.4.0'
             
           # PHP 7.1 Exclusions
+          - php-version: '7.0'
+            mockery-version: '1.6.0'
           - php-version: '7.1'
             mockery-version: '1.5.0'
           - php-version: '7.1'
             mockery-version: '1.4.0'
             
           # PHP 7.0 Exclusions
+          - php-version: '7.0'
+            mockery-version: '1.6.0'
           - php-version: '7.0'
             mockery-version: '1.5.0'
           - php-version: '7.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
             mockery-version: '1.4.0'
             
           # PHP 7.1 Exclusions
-          - php-version: '7.0'
+          - php-version: '7.1'
             mockery-version: '1.6.0'
           - php-version: '7.1'
             mockery-version: '1.5.0'


### PR DESCRIPTION
Ref: https://github.com/mockery/mockery/releases/tag/1.6.0

Note 1.6.0 has been revoked due to https://github.com/mockery/mockery/issues/1266

and instead 1.6.1 has been tagged with PHP 7.4 requirement as min: https://github.com/mockery/mockery/releases/tag/1.6.1
 
